### PR TITLE
Host incorrectly overwritten

### DIFF
--- a/lib/apns/core.rb
+++ b/lib/apns/core.rb
@@ -101,7 +101,7 @@ module APNS
     context.cert = OpenSSL::X509::Certificate.new(File.read(self.pem))
     context.key  = OpenSSL::PKey::RSA.new(File.read(self.pem), self.pass)
 
-    fhost = self.host.gsub!('gateway','feedback')
+    fhost = self.host.gsub('gateway','feedback')
     puts fhost
     
     sock         = TCPSocket.new(fhost, 2196)


### PR DESCRIPTION
We should not use `gsub!`as this will incorrectly modify the host for future calls.
