### PR TITLE
Invalid JSON

### DIFF
--- a/lib/apns/core.rb
+++ b/lib/apns/core.rb
@@ -14,11 +14,8 @@ module APNS
   end
   
   def self.send_notification(device_token, message)
-    sock, ssl = self.open_connection
-    ssl.write(self.packaged_notification(device_token, message))
-
-    ssl.close
-    sock.close
+    n = APNS::Notification.new(device_token, message)
+    self.send_notifications([n])
   end
   
   def self.send_notifications(notifications)
@@ -51,33 +48,6 @@ module APNS
   
   protected
 
-  def self.packaged_notification(device_token, message)
-    pt = self.packaged_token(device_token)
-    pm = self.packaged_message(message)
-    [0, 0, 32, pt, 0, pm.size, pm].pack("ccca*cca*")
-  end
-  
-  def self.packaged_token(device_token)
-    [device_token.gsub(/[\s|<|>]/,'')].pack('H*')
-  end
-  
-  def self.packaged_message(message)
-    if message.is_a?(Hash)
-      apns_from_hash(message)
-    elsif message.is_a?(String)
-      '{"aps":{"alert":"'+ message + '"}}'
-    else
-      raise "Message needs to be either a hash or string"
-    end
-  end
-  
-  def self.apns_from_hash(hash)
-    other = hash.delete(:other)
-    aps = {'aps'=> hash }
-    aps.merge!(other) if other
-    aps.to_json
-  end
-  
   def self.open_connection
     raise "The path to your pem file is not set. (APNS.pem = /path/to/cert.pem)" unless self.pem
     raise "The path to your pem file does not exist!" unless File.exist?(self.pem)


### PR DESCRIPTION
- Remove duplicate packaging logic from core by using APNS::Notification when calling APNS.send_notification
- Fixes issue with invalid json generated when using APNS.send_notification(token, "Hey\nThere")
