### PR TITLE
Added support for Newsstand background download notifications

### DIFF
--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -1,6 +1,6 @@
 module APNS
   class Notification
-    attr_accessor :device_token, :alert, :badge, :sound, :other
+    attr_accessor :device_token, :alert, :badge, :sound, :content_available, :other
     
     def initialize(device_token, message)
       self.device_token = device_token
@@ -8,6 +8,7 @@ module APNS
         self.alert = message[:alert]
         self.badge = message[:badge]
         self.sound = message[:sound]
+        self.content_avaliable = message[:content_available]
         self.other = message[:other]
       elsif message.is_a?(String)
         self.alert = message
@@ -31,6 +32,7 @@ module APNS
       aps['aps']['alert'] = self.alert if self.alert
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
+      aps['aps']['content-available'] = self.content_available if self.content_available
       aps.merge!(self.other) if self.other
       aps.to_json
     end


### PR DESCRIPTION
Newsstand background downloads use APNS notifications with 'aps.content-available' set to true. Added property to the Notification class to include this value.
