### PR TITLE
Support for 3rd gen APNS wire format

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    apns (0.9.0)
+    apns (1.1.0)
 
 GEM
   remote: http://rubygems.org/

--- a/apns.gemspec
+++ b/apns.gemspec
@@ -4,7 +4,6 @@ Gem::Specification.new do |s|
   s.name = %q{apns}
   s.version = "1.1.0"
 
-  s.required_ruby_version = '>= 1.9'
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["James Pozdena", "Thomas Kollbach"]
   s.autorequire = %q{apns}

--- a/apns.gemspec
+++ b/apns.gemspec
@@ -2,14 +2,19 @@
 
 Gem::Specification.new do |s|
   s.name = %q{apns}
-  s.version = "1.0.0"
+  s.version = "1.1.0"
 
+  s.required_ruby_version = '>= 1.9'
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
-  s.authors = ["James Pozdena"]
+  s.authors = ["James Pozdena", "Thomas Kollbach"]
   s.autorequire = %q{apns}
-  s.date = %q{2010-03-22}
-  s.description = %q{Simple Apple push notification service gem}
-  s.email = %q{jpoz@jpoz.net}
+  s.date = %q{2013-06-25}
+  s.description = <<DESC
+Simple Apple push notification service gem.
+It supports the 3rd wire format (command 2) with support for content-availible (Newsstand), expiration dates and delivery priority (background pushes)}
+DESC
+
+  s.email = ["jpoz@jpoz.net", "thomas@kollba.ch"]
   s.extra_rdoc_files = ["MIT-LICENSE"]
   s.files = ["MIT-LICENSE", "README.textile", "Rakefile", "lib/apns", "lib/apns/core.rb", "lib/apns/notification.rb", "lib/apns.rb"]
   s.homepage = %q{http://github.com/jpoz/apns}

--- a/lib/apns/core.rb
+++ b/lib/apns/core.rb
@@ -8,50 +8,49 @@ module APNS
   # openssl pkcs12 -in mycert.p12 -out client-cert.pem -nodes -clcerts
   @pem = nil # this should be the path of the pem file not the contentes
   @pass = nil
-  
+
   class << self
     attr_accessor :host, :pem, :port, :pass
   end
-  
+
   def self.send_notification(device_token, message)
     n = APNS::Notification.new(device_token, message)
     self.send_notifications([n])
   end
-  
+
   def self.send_notifications(notifications)
     sock, ssl = self.open_connection
-    
+
     notifications.each do |n|
       ssl.write(n.packaged_notification)
     end
-    
+
     ssl.close
     sock.close
   end
-  
+
   def self.feedback
     sock, ssl = self.feedback_connection
-    
+
     apns_feedback = []
-    
-    while line = sock.gets   # Read lines from the socket
-      line.strip!
-      f = line.unpack('N1n1H140')
-      apns_feedback << [Time.at(f[0]), f[2]]
+
+    while message = ssl.read(38)
+      timestamp, token_size, token = message.unpack('N1n1H*')
+      apns_feedback << [Time.at(timestamp), token]
     end
-    
+
     ssl.close
     sock.close
-    
+
     return apns_feedback
   end
-  
+
   protected
 
   def self.open_connection
     raise "The path to your pem file is not set. (APNS.pem = /path/to/cert.pem)" unless self.pem
     raise "The path to your pem file does not exist!" unless File.exist?(self.pem)
-    
+
     context      = OpenSSL::SSL::SSLContext.new
     context.cert = OpenSSL::X509::Certificate.new(File.read(self.pem))
     context.key  = OpenSSL::PKey::RSA.new(File.read(self.pem), self.pass)
@@ -62,23 +61,22 @@ module APNS
 
     return sock, ssl
   end
-  
+
   def self.feedback_connection
     raise "The path to your pem file is not set. (APNS.pem = /path/to/cert.pem)" unless self.pem
     raise "The path to your pem file does not exist!" unless File.exist?(self.pem)
-    
+
     context      = OpenSSL::SSL::SSLContext.new
     context.cert = OpenSSL::X509::Certificate.new(File.read(self.pem))
     context.key  = OpenSSL::PKey::RSA.new(File.read(self.pem), self.pass)
 
     fhost = self.host.gsub('gateway','feedback')
     puts fhost
-    
+
     sock         = TCPSocket.new(fhost, 2196)
     ssl          = OpenSSL::SSL::SSLSocket.new(sock,context)
     ssl.connect
 
     return sock, ssl
   end
-  
 end

--- a/lib/apns/core.rb
+++ b/lib/apns/core.rb
@@ -1,4 +1,3 @@
-require 'pp'
 module APNS
   require 'socket'
   require 'openssl'

--- a/lib/apns/core.rb
+++ b/lib/apns/core.rb
@@ -1,3 +1,4 @@
+require 'pp'
 module APNS
   require 'socket'
   require 'openssl'
@@ -21,12 +22,28 @@ module APNS
   def self.send_notifications(notifications)
     sock, ssl = self.open_connection
 
+    packed_nofications = self.packed_nofications(notifications)
+
     notifications.each do |n|
-      ssl.write(n.packaged_notification)
+      ssl.write(packed_nofications)
     end
 
     ssl.close
     sock.close
+  end
+
+  def self.packed_nofications(notifications)
+    bytes = ''
+
+    notifications.each do |notification|
+      # Each notification frame consists of
+      # 1. (e.g. protocol version) 2 (unsigned char [1 byte]) 
+      # 2. size of the full frame (unsigend int [4 byte], big endian)
+      pn = notification.packaged_notification
+      bytes << ([2, pn.bytesize].pack('CN') + pn)
+    end
+
+    bytes
   end
 
   def self.feedback

--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -35,7 +35,7 @@ module APNS
       pm = self.packaged_message
       pi = self.message_identifier
       pe = (self.expiration_date || 0).to_i
-      pr = self.priority
+      pr = (self.priority || 10).to_i
 
       # Each item consist of
       # 1. unsigned char [1 byte] is the item (type) number according to Apple's docs

--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -1,6 +1,10 @@
 module APNS
+  require 'openssl'
+
   class Notification
-    attr_accessor :device_token, :alert, :badge, :sound, :other
+    attr_accessor :device_token, :alert, :badge, :sound, :other, :priority
+    attr_accessor :message_identifier, :expiration_date
+    attr_accessor :content_availible
     
     def initialize(device_token, message)
       self.device_token = device_token
@@ -9,17 +13,42 @@ module APNS
         self.badge = message[:badge]
         self.sound = message[:sound]
         self.other = message[:other]
+        self.message_identifier = message[:message_identifier]
+        self.content_availible = !message[:content_availible].nil?
+        self.expiration_date = message[:expiration_date]
+        self.priority = if self.content_availible
+          message[:priority] || 5
+        else
+          message[:priority] || 10
+        end
       elsif message.is_a?(String)
         self.alert = message
       else
         raise "Notification needs to have either a hash or string"
       end
+
+      self.message_identifier ||= OpenSSL::Random.random_bytes(4)
     end
         
     def packaged_notification
       pt = self.packaged_token
       pm = self.packaged_message
-      [0, 0, 32, pt, 0, pm.bytesize, pm].pack("ccca*cca*")
+      pi = self.message_identifier
+      pe = (self.expiration_date || 0).to_i
+      pr = self.priority
+
+      # Each item consist of
+      # 1. unsigned char [1 byte] is the item (type) number according to Apple's docs
+      # 2. short [big endian, 2 byte] is the size of this item
+      # 3. item data, depending on the type fixed or variable length
+      data = ''
+      data << [1, pt.bytesize, pt].pack("CnA*")
+      data << [2, pm.bytesize, pm].pack("CnA*")
+      data << [3, pi.bytesize, pi].pack("CnA*")
+      data << [4, 4, pe].pack("CnN")
+      data << [5, 1, pr].pack("CnC")
+      
+      data
     end
   
     def packaged_token
@@ -31,9 +60,10 @@ module APNS
       aps['aps']['alert'] = self.alert if self.alert
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
+      aps['aps']['content-availible'] = 1 if self.content_availible
+
       aps.merge!(self.other) if self.other
       aps.to_json
-    end
-    
+    end    
   end
 end

--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -4,7 +4,7 @@ module APNS
   class Notification
     attr_accessor :device_token, :alert, :badge, :sound, :other, :priority
     attr_accessor :message_identifier, :expiration_date
-    attr_accessor :content_availible
+    attr_accessor :content_available
     
     def initialize(device_token, message)
       self.device_token = device_token
@@ -14,9 +14,9 @@ module APNS
         self.sound = message[:sound]
         self.other = message[:other]
         self.message_identifier = message[:message_identifier]
-        self.content_availible = !message[:content_availible].nil?
+        self.content_available = !message[:content_available].nil?
         self.expiration_date = message[:expiration_date]
-        self.priority = if self.content_availible
+        self.priority = if self.content_available
           message[:priority] || 5
         else
           message[:priority] || 10
@@ -60,7 +60,7 @@ module APNS
       aps['aps']['alert'] = self.alert if self.alert
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
-      aps['aps']['content-availible'] = 1 if self.content_availible
+      aps['aps']['content-available'] = 1 if self.content_available
 
       aps.merge!(self.other) if self.other
       aps.to_json

--- a/spec/apns/notification_spec.rb
+++ b/spec/apns/notification_spec.rb
@@ -13,6 +13,12 @@ describe APNS::Notification do
     n.badge.should == 3
   end
   
+  it "should have a priority if content_availible is set"  do
+    n = APNS::Notification.new('device_token', {:content_availible => true})
+    n.content_availible.should be_true
+    n.priority.should eql(5)
+  end
+
   describe '#packaged_message' do
     
     it "should return JSON with notification information" do
@@ -23,6 +29,11 @@ describe APNS::Notification do
     it "should not include keys that are empty in the JSON" do
       n = APNS::Notification.new('device_token', {:badge => 3})
       n.packaged_message.should == "{\"aps\":{\"badge\":3}}"
+    end
+
+    it "should return JSON with content availible" do
+      n = APNS::Notification.new('device_token', {:content_availible => true})
+      n.packaged_message.should  == "{\"aps\":{\"content-availible\":1}}"
     end
     
   end
@@ -37,7 +48,8 @@ describe APNS::Notification do
   describe '#packaged_notification' do
     it "should package the token" do
       n = APNS::Notification.new('device_token', {:alert => 'Hello iPhone', :badge => 3, :sound => 'awesome.caf'})
-      Base64.encode64(n.packaged_notification).should == "AAAg3vLO/YTnAEB7ImFwcyI6eyJhbGVydCI6IkhlbGxvIGlQaG9uZSIsImJh\nZGdlIjozLCJzb3VuZCI6ImF3ZXNvbWUuY2FmIn19\n"
+      n.stub!(:message_identifier).and_return('aaaa') # make sure the message_identifier is not random
+      Base64.encode64(n.packaged_notification).should == "AQAG3vLO/YTnAgBAeyJhcHMiOnsiYWxlcnQiOiJIZWxsbyBpUGhvbmUiLCJi\nYWRnZSI6Mywic291bmQiOiJhd2Vzb21lLmNhZiJ9fQMABGFhYWEEAAQAAAAA\nBQABCg==\n"
     end
   end
   

--- a/spec/apns/notification_spec.rb
+++ b/spec/apns/notification_spec.rb
@@ -14,8 +14,8 @@ describe APNS::Notification do
   end
   
   it "should have a priority if content_availible is set"  do
-    n = APNS::Notification.new('device_token', {:content_availible => true})
-    n.content_availible.should be_true
+    n = APNS::Notification.new('device_token', {:content_available => true})
+    n.content_available.should be_true
     n.priority.should eql(5)
   end
 
@@ -32,8 +32,8 @@ describe APNS::Notification do
     end
 
     it "should return JSON with content availible" do
-      n = APNS::Notification.new('device_token', {:content_availible => true})
-      n.packaged_message.should  == "{\"aps\":{\"content-availible\":1}}"
+      n = APNS::Notification.new('device_token', {:content_available => true})
+      n.packaged_message.should  == "{\"aps\":{\"content-available\":1}}"
     end
     
   end


### PR DESCRIPTION
This adds support for the newest APNS wire format. This adds support for
- `content-available` pushes (e.g Newsstand)
- background pushes
- delivery priority
- push expiration time
- support for notifications IDs allowing removal of read messages on other devices

without breaking API changes.
