### PR TITLE
Error Handling from SendNotifications

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2009 James Pozdena
- 
+
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
 files (the "Software"), to deal in the Software without
@@ -8,10 +8,10 @@ copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the
 Software is furnished to do so, subject to the following
 conditions:
- 
+
 The above copyright notice and this permission notice shall be
 included in all copies or substantial portions of the Software.
- 
+
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
 OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND

--- a/README.textile
+++ b/README.textile
@@ -22,13 +22,13 @@ After you have your .pem file. Set what host, port, certificate file location on
 
 <pre>
   <code>
-    APNS.host = 'gateway.push.apple.com' 
+    APNS.host = 'gateway.push.apple.com'
     # gateway.sandbox.push.apple.com is default
 
     APNS.pem  = '/path/to/pem/file'
     # this is the file you just created
-    
-    APNS.port = 2195 
+
+    APNS.port = 2195
     # this is also the default. Shouldn't ever have to set this, but just in case Apple goes crazy, you can.
   </code>
 </pre>
@@ -58,7 +58,7 @@ You can also send multiple notifications using the same connection to Apple:
     n1 = APNS::Notification.new(device_token, 'Hello iPhone!' )
 
     n2 = APNS::Notification.new(device_token, :alert => 'Hello iPhone!', :badge => 1, :sound => 'default')
-    
+
     APNS.send_notifications([n1, n2])
   </code>
 </pre>
@@ -92,17 +92,17 @@ h3. ApplicationAppDelegate.m
 
 <pre>
   <code>
-    - (void)applicationDidFinishLaunching:(UIApplication *)application 
-    {    
+    - (void)applicationDidFinishLaunching:(UIApplication *)application
+    {
         // Register with apple that this app will use push notification
-        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:(UIRemoteNotificationTypeAlert | 
+        [[UIApplication sharedApplication] registerForRemoteNotificationTypes:(UIRemoteNotificationTypeAlert |
           UIRemoteNotificationTypeSound | UIRemoteNotificationTypeBadge)];
 
         // Your app startup logic...
         return YES;
     }
 
-    - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken 
+    - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
     {
         // Convert the binary data token into an NSString (see below for the implementation of this function)
         NSString *deviceTokenAsString = stringFromDeviceTokenData(deviceToken);
@@ -122,11 +122,11 @@ This snippet comes from "this stackoverflow post's anwser":http://stackoverflow.
     {
       const char *data = [deviceToken bytes];
       NSMutableString* token = [NSMutableString string];
-      
+
       for (int i = 0; i < [deviceToken length]; i++) {
         [token appendFormat:@"%02.2hhX", data[i]];
       }
-      
+
       return [[token copy] autorelease];
     }
   </code>

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rake/gempackagetask'
 require 'rubygems/specification'
 require 'date'
 require 'spec/rake/spectask'
- 
+
 GEM = 'apns'
 GEM_NAME = 'apns'
 GEM_VERSION = '0.9.0'
@@ -11,7 +11,7 @@ AUTHORS = ['James Pozdena']
 EMAIL = "jpoz@jpoz.net"
 HOMEPAGE = "http://github.com/jpoz/apns"
 SUMMARY = "Simple Apple push notification service gem"
- 
+
 spec = Gem::Specification.new do |s|
   s.name = GEM
   s.version = GEM_VERSION
@@ -27,24 +27,24 @@ spec = Gem::Specification.new do |s|
   s.autorequire = GEM
   s.files = %w(MIT-LICENSE README.textile Rakefile) + Dir.glob("{lib}/**/*")
 end
- 
+
 task :default => :spec
- 
+
 desc "Run specs"
 Spec::Rake::SpecTask.new do |t|
   t.spec_files = FileList['spec/**/*_spec.rb']
   t.spec_opts = %w(-fs --color)
 end
- 
+
 Rake::GemPackageTask.new(spec) do |pkg|
   pkg.gem_spec = spec
 end
- 
+
 desc "install the gem locally"
 task :install => [:package] do
   sh %{sudo gem install pkg/#{GEM}-#{GEM_VERSION}}
 end
- 
+
 desc "create a gemspec file"
 task :make_spec do
   File.open("#{GEM}.gemspec", "w") do |file|

--- a/lib/apns/core.rb
+++ b/lib/apns/core.rb
@@ -36,7 +36,7 @@ module APNS
 
     notifications.each do |notification|
       # Each notification frame consists of
-      # 1. (e.g. protocol version) 2 (unsigned char [1 byte]) 
+      # 1. (e.g. protocol version) 2 (unsigned char [1 byte])
       # 2. size of the full frame (unsigend int [4 byte], big endian)
       pn = notification.packaged_notification
       bytes << ([2, pn.bytesize].pack('CN') + pn)

--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -5,6 +5,7 @@ module APNS
     attr_accessor :device_token, :alert, :badge, :sound, :category, :other, :priority
     attr_accessor :message_identifier, :expiration_date
     attr_accessor :content_available
+    attr_accessor :mutable_content
 
     def initialize(device_token, message)
       self.device_token = device_token
@@ -14,6 +15,7 @@ module APNS
         self.sound = message[:sound]
         self.category = message[:category]
         self.other = message[:other]
+        self.mutable_content = message[:mutable_content]
         self.message_identifier = message[:message_identifier]
         self.content_available = !message[:content_available].nil?
         self.expiration_date = message[:expiration_date]
@@ -63,6 +65,7 @@ module APNS
       aps['aps']['sound'] = self.sound if self.sound
       aps['aps']['category'] = self.category if self.category
       aps['aps']['content-available'] = 1 if self.content_available
+      aps['aps']['mutable-content'] = 1 if self.mutable_content
 
       aps.merge!(self.other) if self.other
       aps.to_json

--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -5,7 +5,7 @@ module APNS
     attr_accessor :device_token, :alert, :badge, :sound, :other, :priority
     attr_accessor :message_identifier, :expiration_date
     attr_accessor :content_available
-    
+
     def initialize(device_token, message)
       self.device_token = device_token
       if message.is_a?(Hash)
@@ -29,7 +29,7 @@ module APNS
 
       self.message_identifier ||= OpenSSL::Random.random_bytes(4)
     end
-        
+
     def packaged_notification
       pt = self.packaged_token
       pm = self.packaged_message
@@ -47,14 +47,14 @@ module APNS
       data << [3, pi.bytesize, pi].pack("CnA*")
       data << [4, 4, pe].pack("CnN")
       data << [5, 1, pr].pack("CnC")
-      
+
       data
     end
-  
+
     def packaged_token
       [device_token.gsub(/[\s|<|>]/,'')].pack('H*')
     end
-  
+
     def packaged_message
       aps = {'aps'=> {} }
       aps['aps']['alert'] = self.alert if self.alert
@@ -64,6 +64,6 @@ module APNS
 
       aps.merge!(self.other) if self.other
       aps.to_json
-    end    
+    end
   end
 end

--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -2,7 +2,7 @@ module APNS
   require 'openssl'
 
   class Notification
-    attr_accessor :device_token, :alert, :badge, :sound, :other, :priority
+    attr_accessor :device_token, :alert, :badge, :sound, :category, :other, :priority
     attr_accessor :message_identifier, :expiration_date
     attr_accessor :content_available
 
@@ -12,6 +12,7 @@ module APNS
         self.alert = message[:alert]
         self.badge = message[:badge]
         self.sound = message[:sound]
+        self.category = message[:category]
         self.other = message[:other]
         self.message_identifier = message[:message_identifier]
         self.content_available = !message[:content_available].nil?
@@ -60,6 +61,7 @@ module APNS
       aps['aps']['alert'] = self.alert if self.alert
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
+      aps['aps']['category'] = self.category if self.category
       aps['aps']['content-available'] = 1 if self.content_available
 
       aps.merge!(self.other) if self.other

--- a/spec/apns/notification_spec.rb
+++ b/spec/apns/notification_spec.rb
@@ -41,6 +41,11 @@ describe APNS::Notification do
       n.packaged_message.should  == "{\"aps\":{\"content-available\":1}}"
     end
 
+    it 'should accept mutable-content key only if mentionned' do
+      n = APNS::Notification.new('device_token', {:mutable_content => 1})
+      n.packaged_message.should  == "{\"aps\":{\"mutable-content\":1}}"
+    end
+
   end
 
   describe '#package_token' do

--- a/spec/apns/notification_spec.rb
+++ b/spec/apns/notification_spec.rb
@@ -1,18 +1,18 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 describe APNS::Notification do
-  
+
   it "should take a string as the message" do
     n = APNS::Notification.new('device_token', 'Hello')
     n.alert.should == 'Hello'
   end
-  
+
   it "should take a hash as the message" do
     n = APNS::Notification.new('device_token', {:alert => 'Hello iPhone', :badge => 3})
     n.alert.should == "Hello iPhone"
     n.badge.should == 3
   end
-  
+
   it "should have a priority if content_availible is set"  do
     n = APNS::Notification.new('device_token', {:content_available => true})
     n.content_available.should be_true
@@ -20,12 +20,12 @@ describe APNS::Notification do
   end
 
   describe '#packaged_message' do
-    
+
     it "should return JSON with notification information" do
       n = APNS::Notification.new('device_token', {:alert => 'Hello iPhone', :badge => 3, :sound => 'awesome.caf'})
       n.packaged_message.should  == "{\"aps\":{\"alert\":\"Hello iPhone\",\"badge\":3,\"sound\":\"awesome.caf\"}}"
     end
-    
+
     it "should not include keys that are empty in the JSON" do
       n = APNS::Notification.new('device_token', {:badge => 3})
       n.packaged_message.should == "{\"aps\":{\"badge\":3}}"
@@ -35,9 +35,9 @@ describe APNS::Notification do
       n = APNS::Notification.new('device_token', {:content_available => true})
       n.packaged_message.should  == "{\"aps\":{\"content-available\":1}}"
     end
-    
+
   end
-  
+
   describe '#package_token' do
     it "should package the token" do
       n = APNS::Notification.new('<5b51030d d5bad758 fbad5004 bad35c31 e4e0f550 f77f20d4 f737bf8d 3d5524c6>', 'a')
@@ -52,5 +52,5 @@ describe APNS::Notification do
       Base64.encode64(n.packaged_notification).should == "AQAG3vLO/YTnAgBAeyJhcHMiOnsiYWxlcnQiOiJIZWxsbyBpUGhvbmUiLCJi\nYWRnZSI6Mywic291bmQiOiJhd2Vzb21lLmNhZiJ9fQMABGFhYWEEAAQAAAAA\nBQABCg==\n"
     end
   end
-  
+
 end

--- a/spec/apns/notification_spec.rb
+++ b/spec/apns/notification_spec.rb
@@ -26,6 +26,11 @@ describe APNS::Notification do
       n.packaged_message.should  == "{\"aps\":{\"alert\":\"Hello iPhone\",\"badge\":3,\"sound\":\"awesome.caf\"}}"
     end
 
+    it "should support the iOS 8 category key" do
+      n = APNS::Notification.new('device_token', {:alert => 'Hello iPhone', :badge => 3, :category => 'CATEGORY_IDENTIFIER'})
+      n.packaged_message.should  == "{\"aps\":{\"alert\":\"Hello iPhone\",\"badge\":3,\"category\":\"CATEGORY_IDENTIFIER\"}}"
+    end
+
     it "should not include keys that are empty in the JSON" do
       n = APNS::Notification.new('device_token', {:badge => 3})
       n.packaged_message.should == "{\"aps\":{\"badge\":3}}"


### PR DESCRIPTION
Send notifications can handle errors from the APNS server, giving the client feedback on the result of their pushes.
It is returned: 
- error code
- token index that originated the error

Since APNS processes tokens sequentially, all subsequent tokens will not be processed. So we need a way to pinpoint exactly which token has problems and why.
