### PR TITLE
Can use contents of file

### DIFF
--- a/lib/apns/core.rb
+++ b/lib/apns/core.rb
@@ -85,7 +85,7 @@ module APNS
   end
 
   def self.get_context
-    context      = OpenSSL::SSL::SSLContext.new
+    context = OpenSSL::SSL::SSLContext.new
     if self.pem
       raise "The path to your pem file does not exist!" unless File.exist?(self.pem)
       context.cert = OpenSSL::X509::Certificate.new(File.read(self.pem))


### PR DESCRIPTION
Adds the option of providing the contents of the .pem file instead of the file path. Allows you to encrypt and decrypt the string when it is being used
