### PR TITLE
Add support for iOS 8 new 'category' field.

### DIFF
--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -2,10 +2,10 @@ module APNS
   require 'openssl'
 
   class Notification
-    attr_accessor :device_token, :alert, :badge, :sound, :other, :priority
+    attr_accessor :device_token, :alert, :badge, :sound, :other, :priority, :category
     attr_accessor :message_identifier, :expiration_date
     attr_accessor :content_available
-    
+
     def initialize(device_token, message)
       self.device_token = device_token
       if message.is_a?(Hash)
@@ -13,6 +13,7 @@ module APNS
         self.badge = message[:badge]
         self.sound = message[:sound]
         self.other = message[:other]
+        self.category = message[:category]
         self.message_identifier = message[:message_identifier]
         self.content_available = !message[:content_available].nil?
         self.expiration_date = message[:expiration_date]
@@ -29,7 +30,7 @@ module APNS
 
       self.message_identifier ||= OpenSSL::Random.random_bytes(4)
     end
-        
+
     def packaged_notification
       pt = self.packaged_token
       pm = self.packaged_message
@@ -47,23 +48,24 @@ module APNS
       data << [3, pi.bytesize, pi].pack("CnA*")
       data << [4, 4, pe].pack("CnN")
       data << [5, 1, pr].pack("CnC")
-      
+
       data
     end
-  
+
     def packaged_token
       [device_token.gsub(/[\s|<|>]/,'')].pack('H*')
     end
-  
+
     def packaged_message
       aps = {'aps'=> {} }
       aps['aps']['alert'] = self.alert if self.alert
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
+      aps['aps']['category'] = self.category if self.category
       aps['aps']['content-available'] = 1 if self.content_available
 
       aps.merge!(self.other) if self.other
       aps.to_json
-    end    
+    end
   end
 end

--- a/spec/apns/notification_spec.rb
+++ b/spec/apns/notification_spec.rb
@@ -1,18 +1,18 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
 describe APNS::Notification do
-  
+
   it "should take a string as the message" do
     n = APNS::Notification.new('device_token', 'Hello')
     n.alert.should == 'Hello'
   end
-  
+
   it "should take a hash as the message" do
     n = APNS::Notification.new('device_token', {:alert => 'Hello iPhone', :badge => 3})
     n.alert.should == "Hello iPhone"
     n.badge.should == 3
   end
-  
+
   it "should have a priority if content_availible is set"  do
     n = APNS::Notification.new('device_token', {:content_available => true})
     n.content_available.should be_true
@@ -20,12 +20,12 @@ describe APNS::Notification do
   end
 
   describe '#packaged_message' do
-    
+
     it "should return JSON with notification information" do
       n = APNS::Notification.new('device_token', {:alert => 'Hello iPhone', :badge => 3, :sound => 'awesome.caf'})
       n.packaged_message.should  == "{\"aps\":{\"alert\":\"Hello iPhone\",\"badge\":3,\"sound\":\"awesome.caf\"}}"
     end
-    
+
     it "should not include keys that are empty in the JSON" do
       n = APNS::Notification.new('device_token', {:badge => 3})
       n.packaged_message.should == "{\"aps\":{\"badge\":3}}"
@@ -35,9 +35,13 @@ describe APNS::Notification do
       n = APNS::Notification.new('device_token', {:content_available => true})
       n.packaged_message.should  == "{\"aps\":{\"content-available\":1}}"
     end
-    
+
+    it "should return JSON with category when specified" do
+      n = APNS::Notification.new('device_token', {:category => "CATEGORY_SAMPLE"})
+      n.packaged_message.should == "{\"aps\":{\"category\":\"CATEGORY_SAMPLE\"}}"
+    end
   end
-  
+
   describe '#package_token' do
     it "should package the token" do
       n = APNS::Notification.new('<5b51030d d5bad758 fbad5004 bad35c31 e4e0f550 f77f20d4 f737bf8d 3d5524c6>', 'a')
@@ -52,5 +56,5 @@ describe APNS::Notification do
       Base64.encode64(n.packaged_notification).should == "AQAG3vLO/YTnAgBAeyJhcHMiOnsiYWxlcnQiOiJIZWxsbyBpUGhvbmUiLCJi\nYWRnZSI6Mywic291bmQiOiJhd2Vzb21lLmNhZiJ9fQMABGFhYWEEAAQAAAAA\nBQABCg==\n"
     end
   end
-  
+
 end


### PR DESCRIPTION
This just adds in the ability to pass a category along with push notifications which enables the ability to send categorized notifications as of iOS 8 which is how you specify which actions to apply to the notifications when users interact with them. I've included a test to verify category is included when specified, all tests passed for me.
