### PR TITLE
Adds `category` to notifications payload

### DIFF
--- a/lib/apns/notification.rb
+++ b/lib/apns/notification.rb
@@ -2,7 +2,7 @@ module APNS
   require 'openssl'
 
   class Notification
-    attr_accessor :device_token, :alert, :badge, :sound, :other, :priority
+    attr_accessor :device_token, :alert, :badge, :sound, :other, :priority, :category
     attr_accessor :message_identifier, :expiration_date
     attr_accessor :content_available
     
@@ -13,6 +13,7 @@ module APNS
         self.badge = message[:badge]
         self.sound = message[:sound]
         self.other = message[:other]
+        self.category = message[:category]
         self.message_identifier = message[:message_identifier]
         self.content_available = !message[:content_available].nil?
         self.expiration_date = message[:expiration_date]
@@ -60,6 +61,7 @@ module APNS
       aps['aps']['alert'] = self.alert if self.alert
       aps['aps']['badge'] = self.badge if self.badge
       aps['aps']['sound'] = self.sound if self.sound
+      aps['aps']['category'] = self.category if self.category
       aps['aps']['content-available'] = 1 if self.content_available
 
       aps.merge!(self.other) if self.other

--- a/spec/apns/notification_spec.rb
+++ b/spec/apns/notification_spec.rb
@@ -22,8 +22,8 @@ describe APNS::Notification do
   describe '#packaged_message' do
     
     it "should return JSON with notification information" do
-      n = APNS::Notification.new('device_token', {:alert => 'Hello iPhone', :badge => 3, :sound => 'awesome.caf'})
-      n.packaged_message.should  == "{\"aps\":{\"alert\":\"Hello iPhone\",\"badge\":3,\"sound\":\"awesome.caf\"}}"
+      n = APNS::Notification.new('device_token', {:alert => 'Hello iPhone', :badge => 3, :sound => 'awesome.caf', :category => 'AWESOME_CATEGORY'})
+      n.packaged_message.should  == "{\"aps\":{\"alert\":\"Hello iPhone\",\"badge\":3,\"sound\":\"awesome.caf\",\"category\":\"AWESOME_CATEGORY\"}}"
     end
     
     it "should not include keys that are empty in the JSON" do


### PR DESCRIPTION
This PR adds a category to the APS notifications payload for consumption by the client, as per Apple's [documentation](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1).

Devs: @emmaviolet & @ecaselles